### PR TITLE
Implement `FromStr`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,7 +562,7 @@ impl_ranged! {
 mod tests {
     use std::convert::TryFrom;
 
-    use crate::{OutOfRangeError, U32, FromStrError};
+    use crate::{FromStrError, OutOfRangeError, U32};
 
     #[test]
     fn test_try_from_primitive_to_deranged() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ use core::str::FromStr;
 #[cfg(feature = "std")]
 use std::error::Error;
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TryFromIntError;
 
 impl fmt::Display for TryFromIntError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,14 +61,16 @@ pub struct ParseIntError {
 
 impl ParseIntError {
     /// Outputs the detailed cause of parsing an integer failing.
-    pub const fn kind(&self) -> &IntErrorKind {
+    #[allow(clippy::missing_const_for_fn)] // This function is not const because the counterpart of stdlib isn't
+    pub fn kind(&self) -> &IntErrorKind {
         &self.kind
     }
 
     // Copied from unstable `core::fmt::ParseIntError::__description` in order to implement
     // `fmt::Display`.  Once the function is stabilized, this function can be removed.
     #[doc(hidden)]
-    pub const fn __description(&self) -> &str {
+    #[allow(clippy::missing_const_for_fn)] // This function is not const because the counterpart of stdlib isn't
+    pub fn __description(&self) -> &str {
         match self.kind {
             IntErrorKind::Empty => "cannot parse integer from empty string",
             IntErrorKind::InvalidDigit => "invalid digit found in string",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,8 @@ impl fmt::Display for FromStrError {
         }
     }
 }
+#[cfg(feature = "std")]
+impl Error for FromStrError {}
 
 macro_rules! const_try_opt {
     ($e:expr) => {


### PR DESCRIPTION
I implemented `FromStr`.  `TryFromIntError` was renamed to a more semantic name `OutOfRangeError`.