### PR TITLE
Implement ranged `char` type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
     clippy::missing_errors_doc,
     clippy::must_use_candidate,
     clippy::redundant_pub_crate,
-    clippy::non_ascii_literal,
+    clippy::non_ascii_literal
 )]
 #![doc(test(attr(deny(warnings))))]
 
@@ -563,7 +563,7 @@ impl_ranged! {
 mod tests {
     use std::convert::TryFrom;
 
-    use crate::{TryFromIntError, U32, Char};
+    use crate::{Char, TryFromIntError, U32};
 
     #[test]
     fn test_try_from_primitive_to_deranged() {


### PR DESCRIPTION
I implemented a ranged `char` type.

Many functions (like `checked_*` and `saturating_*`) and traits (like `LowerHex` and `Octal`) are irrational for `char`, so I had to switch it by introducing additional `$is_integral` switch.  Wondering if this (nested macro with more and more booleans) is the preferred way to do so.