### PR TITLE
Remove unnecessary uses of `unsafe`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,11 +310,11 @@ macro_rules! impl_ranged {
         impl<const MIN: $internal, const MAX: $internal> $type<MIN, MAX> {
             /// The smallest value that can be represented by this type.
             // Safety: `MIN` is in range by definition.
-            pub const MIN: Self = unsafe { Self::new_unchecked(MIN) };
+            pub const MIN: Self = Self::new_static::<MIN>();
 
             /// The largest value that can be represented by this type.
             // Safety: `MAX` is in range by definition.
-            pub const MAX: Self = unsafe { Self::new_unchecked(MAX) };
+            pub const MAX: Self = Self::new_static::<MAX>();
 
             /// Expand the range that the value may be in. **Fails to compile** if the new range is
             /// not a superset of the current range.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ macro_rules! impl_ranged {
                     }
                 }
 
-                #[inline(always)]
+                #[inline]
                 pub(crate) const fn new_saturating(value: $internal) -> Self {
                     <Self as $crate::traits::RangeIsValid>::ASSERT;
                     Self(if value < MIN {


### PR DESCRIPTION
The compiler is smart in removing comparisons that it already knows are not true. This allows us to reduce the use of `unsafe` in safe functions without affecting the produced code.

Each one of these code changes has been tested to not produce any difference in the generated assembly in a release build (with the input given as `std::hint::black_box` so the compiler won't optimize on the static value given in code). Of course no guarantees can be given that every Rust compiler on every platform always will make the same optimizations.

I consider `new_saturating` to be a fundamental and useful method to expose publicly, but I left it here as `pub(crate)` as to not change the public API of the library.