### PR TITLE
add infallible conversions between different bit sizes

### DIFF
--- a/deranged/src/lib.rs
+++ b/deranged/src/lib.rs
@@ -1616,3 +1616,135 @@ impl<const MIN: isize, const MAX: isize> rand09::distr::Distribution<RangedIsize
         RangedIsize::new(value).expect("rand failed to generate a valid value")
     }
 }
+
+/// Macro to implement non-fallible `From` conversions for ranged types to other wider/equal ranged
+/// type with different bit sizes.
+///
+/// This allows you to convert, for example, a RangedU8<-100, 100> to a RangedU32<-100, 100> without
+/// having to cast the value manually and keeping the safe range checks.
+///
+/// The macro checks that the source ranged type's range fits within the destination ranged type's
+/// range, and it uses the larger of the two types for the comparison to ensure that the conversion
+/// is valid. It also asserts that the source and destination ranges are valid at compile time.
+
+macro_rules! impl_ranged_from {
+    ($src_ty:ident, $src_ty_base:ty, $dst_ty:ident, $dst_ty_base:ty) => {
+        impl<
+                const MIN: $src_ty_base,
+                const MAX: $src_ty_base,
+                const MIN2: $dst_ty_base,
+                const MAX2: $dst_ty_base,
+            > From<$src_ty<MIN, MAX>> for $dst_ty<MIN2, MAX2>
+        {
+            #[inline(always)]
+            #[allow(trivial_numeric_casts)]
+            fn from(value: $src_ty<MIN, MAX>) -> Self {
+                const {
+                    assert!(MIN <= MAX, "MIN must be less than or equal to MAX");
+                    assert!(MIN2 <= MAX2, "MINU32 must be less than or equal to MAXU32");
+
+                    // compare using the larger of the two types. This doesn't work for
+                    // signed/unsigned
+
+                    if <$src_ty_base>::BITS >= <$dst_ty_base>::BITS {
+                        assert!(
+                            MIN >= MIN2 as $src_ty_base && MAX <= MAX2 as $src_ty_base,
+                            "Source ranged values must fit in destination ranged values"
+                        );
+                    } else {
+                        assert!(
+                            MIN as $dst_ty_base >= MIN2 && MAX as $dst_ty_base <= MAX2,
+                            "Source ranged values must fit in destination ranged values"
+                        );
+                    }
+                };
+
+                unsafe { $dst_ty::new_unchecked(value.get() as $dst_ty_base) }
+            }
+        }
+    };
+}
+
+// U8 to other types
+impl_ranged_from!(RangedU16, u16, RangedU8, u8);
+impl_ranged_from!(RangedU32, u32, RangedU8, u8);
+impl_ranged_from!(RangedU64, u64, RangedU8, u8);
+impl_ranged_from!(RangedU128, u128, RangedU8, u8);
+impl_ranged_from!(RangedUsize, usize, RangedU8, u8);
+
+// U16 to other types
+impl_ranged_from!(RangedU8, u8, RangedU16, u16);
+impl_ranged_from!(RangedU32, u32, RangedU16, u16);
+impl_ranged_from!(RangedU64, u64, RangedU16, u16);
+impl_ranged_from!(RangedU128, u128, RangedU16, u16);
+impl_ranged_from!(RangedUsize, usize, RangedU16, u16);
+
+// U32 to other types
+impl_ranged_from!(RangedU8, u8, RangedU32, u32);
+impl_ranged_from!(RangedU16, u16, RangedU32, u32);
+impl_ranged_from!(RangedU64, u64, RangedU32, u32);
+impl_ranged_from!(RangedU128, u128, RangedU32, u32);
+impl_ranged_from!(RangedUsize, usize, RangedU32, u32);
+
+// U64 to other types
+impl_ranged_from!(RangedU8, u8, RangedU64, u64);
+impl_ranged_from!(RangedU16, u16, RangedU64, u64);
+impl_ranged_from!(RangedU32, u32, RangedU64, u64);
+impl_ranged_from!(RangedU128, u128, RangedU64, u64);
+impl_ranged_from!(RangedUsize, usize, RangedU64, u64);
+
+// U128 to other types
+impl_ranged_from!(RangedU8, u8, RangedU128, u128);
+impl_ranged_from!(RangedU16, u16, RangedU128, u128);
+impl_ranged_from!(RangedU32, u32, RangedU128, u128);
+impl_ranged_from!(RangedU64, u64, RangedU128, u128);
+impl_ranged_from!(RangedUsize, usize, RangedU128, u128);
+
+// usize to other types
+impl_ranged_from!(RangedU8, u8, RangedUsize, usize);
+impl_ranged_from!(RangedU16, u16, RangedUsize, usize);
+impl_ranged_from!(RangedU32, u32, RangedUsize, usize);
+impl_ranged_from!(RangedU64, u64, RangedUsize, usize);
+impl_ranged_from!(RangedU128, u128, RangedUsize, usize);
+
+// I8 to other types
+impl_ranged_from!(RangedI16, i16, RangedI8, i8);
+impl_ranged_from!(RangedI32, i32, RangedI8, i8);
+impl_ranged_from!(RangedI64, i64, RangedI8, i8);
+impl_ranged_from!(RangedI128, i128, RangedI8, i8);
+impl_ranged_from!(RangedIsize, isize, RangedI8, i8);
+
+// I16 to other types
+impl_ranged_from!(RangedI8, i8, RangedI16, i16);
+impl_ranged_from!(RangedI32, i32, RangedI16, i16);
+impl_ranged_from!(RangedI64, i64, RangedI16, i16);
+impl_ranged_from!(RangedI128, i128, RangedI16, i16);
+impl_ranged_from!(RangedIsize, isize, RangedI16, i16);
+
+// I32 to other types
+impl_ranged_from!(RangedI8, i8, RangedI32, i32);
+impl_ranged_from!(RangedI16, i16, RangedI32, i32);
+impl_ranged_from!(RangedI64, i64, RangedI32, i32);
+impl_ranged_from!(RangedI128, i128, RangedI32, i32);
+impl_ranged_from!(RangedIsize, isize, RangedI32, i32);
+
+// I64 to other types
+impl_ranged_from!(RangedI8, i8, RangedI64, i64);
+impl_ranged_from!(RangedI16, i16, RangedI64, i64);
+impl_ranged_from!(RangedI32, i32, RangedI64, i64);
+impl_ranged_from!(RangedI128, i128, RangedI64, i64);
+impl_ranged_from!(RangedIsize, isize, RangedI64, i64);
+
+// I128 to other types
+impl_ranged_from!(RangedI8, i8, RangedI128, i128);
+impl_ranged_from!(RangedI16, i16, RangedI128, i128);
+impl_ranged_from!(RangedI32, i32, RangedI128, i128);
+impl_ranged_from!(RangedI64, i64, RangedI128, i128);
+impl_ranged_from!(RangedIsize, isize, RangedI128, i128);
+
+// usize to other types
+impl_ranged_from!(RangedI8, i8, RangedIsize, isize);
+impl_ranged_from!(RangedI16, i16, RangedIsize, isize);
+impl_ranged_from!(RangedI32, i32, RangedIsize, isize);
+impl_ranged_from!(RangedI64, i64, RangedIsize, isize);
+impl_ranged_from!(RangedI128, i128, RangedIsize, isize);

--- a/deranged/src/tests.rs
+++ b/deranged/src/tests.rs
@@ -10,6 +10,18 @@ use crate::{
     RangedU8, RangedUsize, TryFromIntError,
 };
 
+#[test]
+fn test_ranged_conversion() {
+    // equal range
+    let _: RangedI8<-5, 5> = RangedI16::<-5, 5>::new_static::<3>().into();
+
+    // wider range
+    let _: RangedI8<-6, 6> = RangedI16::<-5, 5>::new_static::<3>().into();
+
+    // the following fails to compile because the source range is wider than the destination range
+    // let _ : RangedI8<-4, 4> = RangedI16::<-5, 5>::new_static::<3>().into();
+}
+
 macro_rules! if_signed {
     (signed $($x:tt)*) => { $($x)* };
     (unsigned $($x:tt)*) => {};


### PR DESCRIPTION
This allows you to convert, for example, a RangedI8<-100, 100> to a RangedI32<-100, 100> without having to cast the value manually and avoiding unnecessary range checks

The macro checks that the source ranged type's range fits within the destination ranged type's range, and it uses the larger of the two types for the comparison to ensure that the conversion is valid. It also asserts that the source and destination ranges are valid at compile time.

``` rust

    // succeeds because range is the same, even if normally
    // this wouldn't be infallible because of the bitness
    let foo = RangedI16::<-5, 5>::new_static::<3>();
    let bar : RangedI8<-5, 5> = foo.into();

    // succeeds because range is larger
    let foo = RangedI16::<-5, 5>::new_static::<3>();
    let bar : RangedI8<-10, 10> = foo.into();

    // fails to compile because range is smaller
    let foo = RangedI16::<-5, 5>::new_static::<3>();
    let bar : RangedI8<-4, 4> = foo.into();
