### PR TITLE
replace use of doc_auto_cfg, doc_cfg_hide features with doc_cfg

### DIFF
--- a/deranged/src/lib.rs
+++ b/deranged/src/lib.rs
@@ -1,9 +1,8 @@
 //! `deranged` is a proof-of-concept implementation of ranged integers.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg_hide))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 #![doc(test(attr(deny(warnings))))]
-#![cfg_attr(docsrs, doc(cfg_hide(docsrs)))]
 
 #[cfg(all(feature = "alloc", any(feature = "serde", feature = "quickcheck")))]
 extern crate alloc;


### PR DESCRIPTION
Resolves this error, which started with `nightly-2025-09-28` (current `nightly`). The error does not reproduce on `nightly-2025-09-27`.

```text
RUSTDOCFLAGS='-Dwarnings --cfg=docsrs' cargo doc --document-private-items
 Documenting deranged v0.5.4 (./deranged/deranged)
error[E0557]: feature has been removed
 --> deranged/src/lib.rs:3:29
  |
3 | #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg_hide))]
  |                             ^^^^^^^^^^^^ feature has been removed
  |
  = note: removed in 1.58.0; see <https://github.com/rust-lang/rust/pull/138907> for more information
  = note: merged into `doc_cfg`

error[E0557]: feature has been removed
 --> deranged/src/lib.rs:3:43
  |
3 | #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg_hide))]
  |                                           ^^^^^^^^^^^^ feature has been removed
  |
  = note: removed in 1.57.0; see <https://github.com/rust-lang/rust/pull/138907> for more information
  = note: merged into `doc_cfg`

error: Compilation failed, aborting rustdoc

For more information about this error, try `rustc --explain E0557`.
error: could not document `deranged`
```

PR linked in error message:
https://github.com/rust-lang/rust/pull/138907

Similar change made to rattatui in last few hours:
https://github.com/ratatui/ratatui/pull/2103

