### PR TITLE
Add `use std::panic` in tests

### DIFF
--- a/deranged/src/tests.rs
+++ b/deranged/src/tests.rs
@@ -1,8 +1,8 @@
 extern crate std;
 
 use core::hash::Hash;
-use std::format;
 use std::prelude::rust_2021::*;
+use std::{format, panic};
 
 use crate::{
     IntErrorKind, OptionRangedI128, OptionRangedI16, OptionRangedI32, OptionRangedI64,


### PR DESCRIPTION
Fixes `ambiguous_panic_imports` warning added in Rust 1.94 (https://github.com/rust-lang/rust/issues/147319)
```
error: `panic` is ambiguous
   --> deranged/src/tests.rs:438:111
    |
438 |                           $t::<{ $inner::MIN}, { $inner::MAX - 1 }>::new($inner::MIN + i - 1).unwrap_or_else(|| panic!("adding {i}+...
    |                                                                                                                 ^^^^^ ambiguous name
...
732 | / tests![
733 | |     signed OptionRangedI8 RangedI8 i8,
734 | |     signed OptionRangedI16 RangedI16 i16,
735 | |     signed OptionRangedI32 RangedI32 i32,
...   |
744 | |     unsigned OptionRangedUsize RangedUsize usize,
745 | | ];
    | |_- in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
note: `panic` could refer to the macro imported here
   --> deranged/src/tests.rs:6:5
    |
  6 | use std::prelude::rust_2021::*;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `panic` to disambiguate
    = help: or use `self::panic` to refer to this macro unambiguously
note: `panic` could also refer to the macro defined here
   --> ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/prelude/mod.rs:41:13
    |
 41 |     pub use super::v1::*;
    |             ^^^^^^^^^
    = note: `-D ambiguous-panic-imports` implied by `-D future-incompatible`
    = help: to override `-D future-incompatible` add `#[allow(ambiguous_panic_imports)]`
    = note: this error originates in the macro `tests` (in Nightly builds, run with -Z macro-backtrace for more info)

```