### PR TITLE
Add `From<bool>` and `Into<bool>` implementations for Ranged*

### DIFF
--- a/deranged/src/lib.rs
+++ b/deranged/src/lib.rs
@@ -1549,6 +1549,33 @@ macro_rules! impl_ranged {
             }
         })+
 
+        impl<const MIN: $internal, const MAX: $internal> From<bool> for $type<MIN, MAX> {
+            #[inline(always)]
+            fn from(value: bool) -> Self {
+                const {
+                    assert!(MIN <= MAX);
+                    assert!(MIN <= 0, "false cannot be represented in the range");
+                    assert!(MAX >= 1, "true cannot be represented in the range");
+                }
+
+                // Safety: The range can fit both false and true.
+                unsafe { $type::new_unchecked(value as $internal) }
+            }
+        }
+
+        impl<const MIN: $internal, const MAX: $internal> Into<bool> for $type<MIN, MAX> {
+            #[inline(always)]
+            #[allow(unused_comparisons)]
+            fn into(self) -> bool {
+                const {
+                    assert!(MIN <= MAX);
+                    assert!(MIN >= 0 && MAX <= 1, "the range contains values not representable by bool");
+                }
+
+                *self.0 == 1
+            }
+        }
+
         #[cfg(feature = "serde")]
         impl<const MIN: $internal, const MAX: $internal> serde_core::Serialize for $type<MIN, MAX> {
             #[inline(always)]

--- a/deranged/src/tests.rs
+++ b/deranged/src/tests.rs
@@ -597,6 +597,9 @@ macro_rules! tests {
 
         #[test]
         fn from() {$(
+            assert_eq!(<$t::<0, 10> as From<bool>>::from(false).get(), 0);
+            assert_eq!(<$t::<0, 10> as From<bool>>::from(true).get(), 1);
+
             assert_eq!($inner::from($t::<5, 10>::MAX), 10);
             assert_eq!($inner::from($t::<5, 10>::MIN), 5);
 
@@ -622,6 +625,12 @@ macro_rules! tests {
             assert_eq!("4".parse::<$t<5, 10>>(), Err(ParseIntError { kind: IntErrorKind::NegOverflow }));
             assert_eq!("11".parse::<$t<5, 10>>(), Err(ParseIntError { kind: IntErrorKind::PosOverflow }));
             assert_eq!("".parse::<$t<5, 10>>(), Err(ParseIntError { kind: IntErrorKind::Empty }));
+        )*}
+
+        #[test]
+        fn into() {$(
+            assert_eq!(<$t::<0, 1> as Into<bool>>::into($t::<0, 1>::new_static::<0>()), false);
+            assert_eq!(<$t::<0, 1> as Into<bool>>::into($t::<0, 1>::new_static::<1>()), true);
         )*}
 
         #[cfg(feature = "serde")]


### PR DESCRIPTION
Rust's built-in integer types implement `From<bool>`, so I think it makes sense for `Ranged*` to implement it as well, `Into<bool>` is a bit more controversial, but I think it makes sense for values representable in a bool

The tests are failing because of a new warning, this issue is fixed in #27 