### PR TITLE
Add `overflowing_add` and `overflowing_sub` to Ranged*

### DIFF
--- a/deranged/src/lib.rs
+++ b/deranged/src/lib.rs
@@ -1075,6 +1075,54 @@ macro_rules! impl_ranged {
                     ) }
                 }
             }
+
+            /// Calculates self + rhs.
+            ///
+            /// Returns a tuple of the addition along with a boolean indicating whether an arithmetic overflow would occur.
+            /// If an overflow would have occurred then the wrapped value is returned.
+            #[must_use = "this returns the result of the operation, without modifying the original"]
+            #[inline]
+            pub const fn overflowing_add(self, rhs: $internal) -> (Self, bool) {
+                const { assert!(MIN <= MAX); }
+
+                // Forward to internal type's impl if same as type.
+                if MIN == $internal::MIN && MAX == $internal::MAX {
+                    let (res, overflow) = self.get().overflowing_add(rhs);
+
+                    // Safety: std's wrapping methods match ranged arithmetic when the range is the internal datatype's range.
+                    return (unsafe { Self::new_unchecked(res) }, overflow)
+                }
+
+                if let Some(res) = self.checked_add(rhs) {
+                    (res, false)
+                } else {
+                    (self.wrapping_add(rhs), true)
+                }
+            }
+
+            /// Calculates self - rhs.
+            ///
+            /// Returns a tuple of the subtraction along with a boolean indicating whether an arithmetic overflow would occur.
+            /// If an overflow would have occurred then the wrapped value is returned.
+            #[must_use = "this returns the result of the operation, without modifying the original"]
+            #[inline]
+            pub const fn overflowing_sub(self, rhs: $internal) -> (Self, bool) {
+                const { assert!(MIN <= MAX); }
+
+                // Forward to internal type's impl if same as type.
+                if MIN == $internal::MIN && MAX == $internal::MAX {
+                    let (res, overflow) = self.get().overflowing_sub(rhs);
+
+                    // Safety: std's wrapping methods match ranged arithmetic when the range is the internal datatype's range.
+                    return (unsafe { Self::new_unchecked(res) }, overflow)
+                }
+
+                if let Some(res) = self.checked_sub(rhs) {
+                    (res, false)
+                } else {
+                    (self.wrapping_sub(rhs), true)
+                }
+            }
         }
 
         impl<const MIN: $internal, const MAX: $internal> $optional_type<MIN, MAX> {

--- a/deranged/src/tests.rs
+++ b/deranged/src/tests.rs
@@ -497,6 +497,18 @@ macro_rules! tests {
         }
 
         #[test]
+        fn overflowing_add() {$(
+            assert_eq!($t::<5, 10>::MAX.overflowing_add(0), ($t::<5, 10>::MAX, false));
+            assert_eq!($t::<5, 10>::MAX.overflowing_add(1), ($t::<5, 10>::MIN, true));
+        )*}
+
+        #[test]
+        fn overflowing_sub() {$(
+            assert_eq!($t::<5, 10>::MIN.overflowing_sub(0), ($t::<5, 10>::MIN, false));
+            assert_eq!($t::<5, 10>::MIN.overflowing_sub(1), ($t::<5, 10>::MAX, true));
+        )*}
+
+        #[test]
         fn saturating_sub() {$(
             assert_eq!($t::<5, 10>::MIN.saturating_sub(0), $t::<5, 10>::MIN);
             assert_eq!($t::<5, 10>::MIN.saturating_sub(1), $t::<5, 10>::MIN);


### PR DESCRIPTION
Rust's built-in integer types already have these methods, so it makes sense to include them as well

The tests are failing because of a new warning, this issue is fixed in https://github.com/jhpratt/deranged/pull/27