### PR TITLE
Add `new_wrapping` to Ranged*

### DIFF
--- a/deranged/src/lib.rs
+++ b/deranged/src/lib.rs
@@ -385,6 +385,17 @@ macro_rules! impl_ranged {
                 }
             }
 
+            /// Creates a ranged integer with the given value, wrapping if it is out of range.
+            #[inline]
+            pub const fn new_wrapping(value: $internal) -> Self {
+                const { assert!(MIN <= MAX); }
+                if value > MAX {
+                    Self::MAX.wrapping_add(value - MAX)
+                } else {
+                    Self::MAX.wrapping_sub(MAX - value)
+                }
+            }
+
             /// Emit a hint to the compiler that the value is in range.
             ///
             /// In some situations, this can help the optimizer to generate better code. In edge

--- a/deranged/src/tests.rs
+++ b/deranged/src/tests.rs
@@ -206,6 +206,13 @@ macro_rules! tests {
         )*}
 
         #[test]
+        fn new_wrapping() {$(
+            assert_eq!($t::<5, 10>::new_wrapping(11), $t::<5, 10>::MIN);
+            assert_eq!($t::<5, 10>::new_wrapping(4), $t::<5, 10>::MAX);
+            assert_eq!($t::<5, 10>::new_wrapping(9), $t::<5, 10>::new_static::<9>());
+        )*}
+
+        #[test]
         fn from_str_radix() {$(
             assert_eq!($t::<5, 10>::from_str_radix("10", 10), Ok($t::<5, 10>::MAX));
             assert_eq!($t::<5, 10>::from_str_radix("5", 10), Ok($t::<5, 10>::MIN));


### PR DESCRIPTION
`Ranged*` already have `new_saturating`, so I think it makes sense

The tests are failing because of a new warning, this issue is fixed in https://github.com/jhpratt/deranged/pull/27